### PR TITLE
Use `int` schema for `time-millis` logical schema.

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -244,6 +244,7 @@ To output with millisecond precision instead (logical type ``timestamp-millis``)
 | Avro logical type: ``time-micros``
 
 To output with millisecond precision instead (logical type ``time-millis``), use :attr:`py_avro_schema.Option.MILLISECONDS`.
+In that case, the Avro schema is ``int``.
 
 
 :class:`datetime.timedelta`

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -337,7 +337,11 @@ class TimeSchema(Schema):
     def data(self, names: NamesType) -> JSONObj:
         """Return the schema data"""
         logical_type = "time-millis" if Option.MILLISECONDS in self.options else "time-micros"
-        return {"type": "long", "logicalType": logical_type}
+        type_by_logical_type = {
+            "time-millis": "int",
+            "time-micros": "long",
+        }
+        return {"type": type_by_logical_type[logical_type], "logicalType": logical_type}
 
     def make_default(self, py_default: datetime.time) -> int:
         """Return an Avro schema compliant default value for a given Python value"""

--- a/tests/test_logicals.py
+++ b/tests/test_logicals.py
@@ -37,7 +37,7 @@ def test_time():
 def test_time_milliseconds():
     py_type = datetime.time
     expected = {
-        "type": "long",
+        "type": "int",
         "logicalType": "time-millis",
     }
     options = pas.Option.MILLISECONDS


### PR DESCRIPTION
Logical schema `time-micros` will keep using `long` schemas as per Avro specification.