### PR TITLE
Represent List[Dict[str, Any]] as JSON logical type

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -214,6 +214,23 @@ Arbitrary Python dictionaries could be serialized as a ``bytes`` Avro schema by 
 To support JSON serialization as *strings* instead of *bytes*, use :attr:`py_avro_schema.Option.LOGICAL_JSON_STRING`.
 
 
+:class:`typing.List[typing.Dict[str, typing.Any]]`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. seealso::
+
+   For a "normal" Avro ``array`` schema using fully typed Python lists of dictionaries, see :ref:`types::class:`typing.sequence``.
+
+
+| Avro schema: ``bytes``
+| Avro logical type: ``json``
+
+Arbitrary lists of Python dictionaries could be serialized as a ``bytes`` Avro schema by first serializing the data as JSON.
+**py-avro-schema** supports this "JSON-in-Avro" approach by adding the **custom** logical type ``json`` to a ``bytes`` schema.
+
+To support JSON serialization as *strings* instead of *bytes*, use :attr:`py_avro_schema.Option.LOGICAL_JSON_STRING`.
+
+
 :class:`typing.Mapping`
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -221,7 +238,8 @@ Avro schema: ``map``
 
 This supports other "generic type" versions of :class:`collections.abc.Mapping`, including :class:`typing.Dict`.
 
-Avro ``map`` schemas support **string** keys only. Map values can be any other Python type supported by **py-avro-schema**. For example, ``Dict[str, int]`` is output as:
+Avro ``map`` schemas support **string** keys only. Map values can be any other Python type supported by **py-avro-schema**.
+For example, ``Dict[str, int]`` is output as:
 
 .. code-block:: json
 

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -603,57 +603,6 @@ def test_namespaced_enum_field():
     assert_schema(PyType, expected, namespace="my_package.my_module")
 
 
-def test_dict_json_logical_string_field():
-    @dataclasses.dataclass
-    class PyType:
-        field_a: Dict[str, Any] = dataclasses.field(
-            metadata={"avro_adapter": {"logical_type": "json"}},
-            default_factory=dict,
-        )
-
-    expected = {
-        "type": "record",
-        "name": "PyType",
-        "fields": [
-            {
-                "name": "field_a",
-                "type": {
-                    "type": "string",
-                    "logicalType": "json",
-                },
-                "default": "{}",
-            }
-        ],
-    }
-    options = pas.Option.LOGICAL_JSON_STRING
-    assert_schema(PyType, expected, options=options)
-
-
-def test_dict_json_logical_bytes_field():
-    @dataclasses.dataclass
-    class PyType:
-        field_a: Dict[str, Any] = dataclasses.field(
-            metadata={"avro_adapter": {"logical_type": "json"}},
-            default_factory=dict,
-        )
-
-    expected = {
-        "type": "record",
-        "name": "PyType",
-        "fields": [
-            {
-                "name": "field_a",
-                "type": {
-                    "type": "bytes",
-                    "logicalType": "json",
-                },
-                "default": "{}",
-            }
-        ],
-    }
-    assert_schema(PyType, expected)
-
-
 def test_decimal_field_default():
     @dataclasses.dataclass
     class PyType:

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -14,7 +14,7 @@ import datetime
 import decimal
 import enum
 import re
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 import pytest
 

--- a/tests/test_logicals.py
+++ b/tests/test_logicals.py
@@ -11,6 +11,7 @@
 
 import datetime
 import uuid
+from typing import Any, Dict
 
 import py_avro_schema as pas
 from py_avro_schema._testing import assert_schema
@@ -110,5 +111,24 @@ def test_uuid():
     expected = {
         "type": "string",
         "logicalType": "uuid",
+    }
+    assert_schema(py_type, expected)
+
+
+def test_dict_json_logical_string_field():
+    py_type = Dict[str, Any]
+    expected = {
+        "type": "string",
+        "logicalType": "json",
+    }
+    options = pas.Option.LOGICAL_JSON_STRING
+    assert_schema(py_type, expected, options=options)
+
+
+def test_dict_json_logical_bytes_field():
+    py_type = Dict[str, Any]
+    expected = {
+        "type": "bytes",
+        "logicalType": "json",
     }
     assert_schema(py_type, expected)

--- a/tests/test_logicals.py
+++ b/tests/test_logicals.py
@@ -11,7 +11,7 @@
 
 import datetime
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import py_avro_schema as pas
 from py_avro_schema._testing import assert_schema
@@ -127,6 +127,25 @@ def test_dict_json_logical_string_field():
 
 def test_dict_json_logical_bytes_field():
     py_type = Dict[str, Any]
+    expected = {
+        "type": "bytes",
+        "logicalType": "json",
+    }
+    assert_schema(py_type, expected)
+
+
+def test_list_json_logical_string_field():
+    py_type = List[Dict[str, Any]]
+    expected = {
+        "type": "string",
+        "logicalType": "json",
+    }
+    options = pas.Option.LOGICAL_JSON_STRING
+    assert_schema(py_type, expected, options=options)
+
+
+def test_list_json_logical_bytes_field():
+    py_type = List[Dict[str, Any]]
     expected = {
         "type": "bytes",
         "logicalType": "json",


### PR DESCRIPTION
Same as for `Dict[str, Any]`

Is this a new major release? Arguably yes since previously we would have generated this as `array[json]` instead of just JSON (string or bytes).