### PR TITLE
feat(pydantic): allow pydantic model instances as defaults (#64)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,7 @@
 [flake8]
 # Flake 8 linting configuration, not supported in pyproject.toml
 
-ignore = E203,W503
+ignore = E203,W503,E701
 max-line-length = 120
 exclude =
   .svn,

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -619,8 +619,9 @@ class UnionSchema(Schema):
 
         # Support for `X | Y` syntax available in Python 3.10+
         # equivalent to `typing.Union[X, Y]`
-        if getattr(types, "UnionType", None):
-            return origin == Union or origin == types.UnionType  # noqa: E721
+        union_type = getattr(types, "UnionType", None)
+        if union_type:
+            return origin == Union or origin == union_type
         return origin == Union
 
     def __init__(self, py_type: Type[Union[Any]], namespace: Optional[str] = None, options: Option = Option(0)):

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -862,6 +862,7 @@ class DataclassSchema(RecordSchema):
             default=default,
             options=self.options,
         )
+
         return field_obj
 
 
@@ -899,6 +900,9 @@ class PydanticSchema(RecordSchema):
             docs=py_field.description or "",
             options=self.options,
         )
+        # allow to use pydantic models as default values
+        if PydanticSchema.handles_type(default.__class__):
+            field_obj.default = default.model_dump(mode="json")  # type: ignore
         return field_obj
 
     def _annotation(self, field_name: str) -> Type:

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -567,9 +567,6 @@ class SequenceSchema(Schema):
             "items": self.items_schema.data(names=names),
         }
 
-    def make_default(self, py_default: Any) -> Any:
-        return [_schema_obj(default.__class__).make_default(default) for default in py_default]
-
 
 class DictSchema(Schema):
     """An Avro map schema for a given Python mapping"""
@@ -907,7 +904,10 @@ class PydanticSchema(RecordSchema):
 
     def make_default(self, py_default: Any) -> Any:
         """Return an Avro schema compliant default value for a given Python value"""
-        return {key: _schema_obj(value.__class__).make_default(value) for key, value in py_default}
+        try:
+            return {key: _schema_obj(value.__class__).make_default(value) for key, value in py_default}
+        except TypeNotSupportedError:
+            return py_default
 
     def _annotation(self, field_name: str) -> Type:
         """

--- a/src/py_avro_schema/_schemas.py
+++ b/src/py_avro_schema/_schemas.py
@@ -902,12 +902,9 @@ class PydanticSchema(RecordSchema):
         )
         return field_obj
 
-    def make_default(self, py_default: Any) -> Any:
+    def make_default(self, py_default: pydantic.BaseModel) -> JSONObj:
         """Return an Avro schema compliant default value for a given Python value"""
-        try:
-            return {key: _schema_obj(value.__class__).make_default(value) for key, value in py_default}
-        except TypeNotSupportedError:
-            return py_default
+        return {key: _schema_obj(value.__class__).make_default(value) for key, value in py_default}
 
     def _annotation(self, field_name: str) -> Type:
         """

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -44,8 +44,7 @@ def test_str_annotated():
 
 
 def test_str_subclass():
-    class PyType(str):
-        ...
+    class PyType(str): ...
 
     expected = {
         "type": "string",
@@ -55,8 +54,7 @@ def test_str_subclass():
 
 
 def test_str_subclass_namespaced():
-    class PyType(str):
-        ...
+    class PyType(str): ...
 
     expected = {
         "type": "string",
@@ -68,8 +66,7 @@ def test_str_subclass_namespaced():
 def test_str_subclass_other_classes():
     import packaging.version
 
-    class PyType(packaging.version.Version, str):
-        ...
+    class PyType(packaging.version.Version, str): ...
 
     expected = {
         "type": "string",

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -531,22 +531,33 @@ def test_base_model_defaults():
 
     class PyType(pydantic.BaseModel):
         default: Default = pydantic.Field(..., default_factory=Default)
-        defaults: list[Default] = pydantic.Field(..., default_factory=lambda: [Default()])
+
+    class Nested(pydantic.BaseModel):
+        py_type: PyType = pydantic.Field(..., default_factory=PyType)
 
     expected = {
         "fields": [
             {
-                "default": {"field_a": "default_a"},
-                "name": "default",
+                "default": {"default": {"field_a": "default_a"}},
+                "name": "py_type",
                 "type": {
-                    "fields": [{"default": "default_a", "name": "field_a", "type": "string"}],
-                    "name": "Default",
+                    "fields": [
+                        {
+                            "default": {"field_a": "default_a"},
+                            "name": "default",
+                            "type": {
+                                "fields": [{"default": "default_a", "name": "field_a", "type": "string"}],
+                                "name": "Default",
+                                "type": "record",
+                            },
+                        }
+                    ],
+                    "name": "PyType",
                     "type": "record",
                 },
-            },
-            {"default": [{"field_a": "default_a"}], "name": "defaults", "type": {"items": "Default", "type": "array"}},
+            }
         ],
-        "name": "PyType",
+        "name": "Nested",
         "type": "record",
     }
-    assert_schema(PyType, expected)
+    assert_schema(Nested, expected)

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -523,3 +523,28 @@ def test_annotated_decimal_overridden():
         ],
     }
     assert_schema(PyType, expected)
+
+
+def test_base_model_defaults():
+    class Default(pydantic.BaseModel):
+        field_a: str = "default_a"
+
+    class PyType(pydantic.BaseModel):
+        default: Default = pydantic.Field(..., default_factory=Default)
+
+    expected = {
+        "fields": [
+            {
+                "default": {"field_a": "default_a"},
+                "name": "default",
+                "type": {
+                    "fields": [{"default": "default_a", "name": "field_a", "type": "string"}],
+                    "name": "Default",
+                    "type": "record",
+                },
+            }
+        ],
+        "name": "PyType",
+        "type": "record",
+    }
+    assert_schema(PyType, expected)

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -531,6 +531,7 @@ def test_base_model_defaults():
 
     class PyType(pydantic.BaseModel):
         default: Default = pydantic.Field(..., default_factory=Default)
+        defaults: list[Default] = pydantic.Field(..., default_factory=lambda: [Default()])
 
     expected = {
         "fields": [
@@ -542,7 +543,8 @@ def test_base_model_defaults():
                     "name": "Default",
                     "type": "record",
                 },
-            }
+            },
+            {"default": [{"field_a": "default_a"}], "name": "defaults", "type": {"items": "Default", "type": "array"}},
         ],
         "name": "PyType",
         "type": "record",


### PR DESCRIPTION
This allows pydantic BaseModels as default values.

Fixes #64 